### PR TITLE
Diagnose -i arg (#14)

### DIFF
--- a/Sources/SwiftDriver/Driver/Driver.swift
+++ b/Sources/SwiftDriver/Driver/Driver.swift
@@ -688,8 +688,7 @@ extension Driver {
         compilerOutputType = nil
 
       case .i:
-        // FIXME: diagnose this
-        break
+        diagnosticsEngine.emit(.error_i_mode(driverKind))
 
       case .repl, .deprecatedIntegratedRepl, .lldbRepl:
         compilerOutputType = nil
@@ -704,6 +703,17 @@ extension Driver {
     }
 
     return (compilerOutputType, linkerOutputType)
+  }
+}
+
+extension Diagnostic.Message {
+  public static func error_i_mode(_ driverKind: DriverKind) -> Diagnostic.Message {
+    .error(
+      """
+      the flag '-i' is no longer required and has been removed; \
+      use '\(driverKind.usage) input-filename'
+      """
+    )
   }
 }
 

--- a/Tests/SwiftDriverTests/SwiftDriverTests.swift
+++ b/Tests/SwiftDriverTests/SwiftDriverTests.swift
@@ -142,6 +142,12 @@ final class SwiftDriverTests: XCTestCase {
     XCTAssertEqual(driver3.linkerOutputType, .staticLibrary)
   }
 
+  func testPrimaryOutputKindsDiagnostics() throws {
+      try assertDriverDiagnostics(args: "swift", "-i") {
+          $1.expect(.error_i_mode(.interactive))
+      }
+  }
+
   func testDebugSettings() throws {
     try assertNoDriverDiagnostics(args: "swiftc", "foo.swift", "-emit-module") { driver in
       XCTAssertNil(driver.debugInfoLevel)


### PR DESCRIPTION
* Diagnose usage of -i argument.

* Removed newline in diagnostic message